### PR TITLE
remove JOB_ID from the requiered variables

### DIFF
--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -51,7 +51,8 @@ jobs:
 
       # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
       - name: get job id
-        run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | awk 'NR==4 {print $1}')
+        run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | grep -Eo '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | awk 'NR==1 {print $1}')
+            ./cpdctl job list --project-id $PROJECT_ID
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}
 

--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -51,6 +51,12 @@ jobs:
 
       # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
       - name: get job id
+        run: ./cpdctl job list --project-id $PROJECT_ID
+        env:
+          PROJECT_ID: ${{ secrets.PROJECT_ID}}
+      
+      # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
+      - name: get job id
         run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | grep -Eo '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | awk 'NR==1 {print $1}')
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}

--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -49,15 +49,9 @@ jobs:
           USER_NAME: ${{ secrets.USER_NAME}}
           API_KEY: ${{ secrets.API_KEY}}
 
-      # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
+
       - name: get job id
-        run: ./cpdctl job list --project-id $PROJECT_ID
-        env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID}}
-      
-      # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
-      - name: get job id
-        run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | grep -Eo '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | awk 'NR==1 {print $1}')
+        run: echo "JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | grep -Eo '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | awk 'NR==1 {print $1}')" >> $GITHUB_ENV
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}
 

--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -51,7 +51,7 @@ jobs:
 
       # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
       - name: get job id
-        run: ./cpdctl job list --project-id $PROJECT_ID
+        run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | awk 'NR==4 {print $1}')
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}
         
@@ -60,5 +60,4 @@ jobs:
         run: |
           ./cpdctl job run create --job-id $JOB_ID --project-id $PROJECT_ID --job-run='{"configuration": {"env_variables": []}, "description": "Description", "job_parameters": [], "name": "Name", "parameter_sets": []}'
         env:
-          JOB_ID: ${{ secrets.JOB_ID}}
           PROJECT_ID: ${{ secrets.PROJECT_ID}}

--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -54,6 +54,10 @@ jobs:
         run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | awk 'NR==4 {print $1}')
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}
+
+      # debug!
+      - name: Run a one-line script
+        run: echo "This is Job ID, $JOB_ID!"
         
       # Runs a pipeline job
       - name: Run pipeline job

--- a/.github/workflows/watson-pipelines.yaml
+++ b/.github/workflows/watson-pipelines.yaml
@@ -52,7 +52,6 @@ jobs:
       # gets the job id (just for debugging. JOB_ID is actually hardcoded right now)
       - name: get job id
         run: export JOB_ID=$(./cpdctl job list --project-id $PROJECT_ID | grep -Eo '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' | awk 'NR==1 {print $1}')
-            ./cpdctl job list --project-id $PROJECT_ID
         env:
           PROJECT_ID: ${{ secrets.PROJECT_ID}}
 


### PR DESCRIPTION
by assuming that there is only ONE job in the 02_automation_area project we can retrieve the job id within the github action --> this makes things A LOT easier to set up